### PR TITLE
fix: use bg-opacity instead of opacity in profile card

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
   <div class="max-w-4xl flex items-center h-auto lg:h-screen flex-wrap mx-auto my-32 lg:my-0">
     
 	<!--Main Col-->
-	<div id="profile" class="w-full lg:w-3/5 rounded-lg lg:rounded-l-lg lg:rounded-r-none shadow-2xl bg-white opacity-75 mx-6 lg:mx-0">
+	<div id="profile" class="w-full lg:w-3/5 rounded-lg lg:rounded-l-lg lg:rounded-r-none shadow-2xl bg-white bg-opacity-75 mx-6 lg:mx-0">
 	
 
 		<div class="p-4 md:p-12 text-center lg:text-left">


### PR DESCRIPTION
to avoid opacity in mobile profile picture

### Before
<img width="470" alt="Screenshot 2024-06-29 at 13 47 20" src="https://github.com/tailwindtoolbox/Profile-Card/assets/25413225/748e55d7-23eb-4587-a674-d626e5e3326f">

### After
<img width="472" alt="Screenshot 2024-06-29 at 13 47 43" src="https://github.com/tailwindtoolbox/Profile-Card/assets/25413225/701acabd-44d4-4ac8-879b-fb0b4bca10b2">
